### PR TITLE
Fix constructor parameter names

### DIFF
--- a/core/src/main/java/com/farmgame/ui/AnimalSelectionWindow.java
+++ b/core/src/main/java/com/farmgame/ui/AnimalSelectionWindow.java
@@ -17,12 +17,12 @@ public class AnimalSelectionWindow extends Window {
     private final Player player;
     private final DifficultyManager difficultyManager;
 
-    public AnimalSelectionWindow(String tile, Skin skin, Player player, AnimalPen animalPen, Runnable onBuyCallback){
-        this(tile, skin, player, animalPen, onBuyCallback, new DifficultyManager());
+    public AnimalSelectionWindow(String title, Skin skin, Player player, AnimalPen animalPen, Runnable onBuyCallback){
+        this(title, skin, player, animalPen, onBuyCallback, new DifficultyManager());
     }
 
-    public AnimalSelectionWindow(String tile, Skin skin, Player player, AnimalPen animalPen, Runnable onBuyCallback, float difficultyMultiplier){
-        this(tile, skin, player, animalPen, onBuyCallback, createDifficultyManager(difficultyMultiplier));
+    public AnimalSelectionWindow(String title, Skin skin, Player player, AnimalPen animalPen, Runnable onBuyCallback, float difficultyMultiplier){
+        this(title, skin, player, animalPen, onBuyCallback, createDifficultyManager(difficultyMultiplier));
     }
 
     private static DifficultyManager createDifficultyManager(float multiplier) {
@@ -31,8 +31,8 @@ public class AnimalSelectionWindow extends Window {
         return manager;
     }
 
-    public AnimalSelectionWindow(String tile, Skin skin, Player player, AnimalPen animalPen, Runnable onBuyCallback, DifficultyManager difficultyManager){
-        super(tile, skin);
+    public AnimalSelectionWindow(String title, Skin skin, Player player, AnimalPen animalPen, Runnable onBuyCallback, DifficultyManager difficultyManager){
+        super(title, skin);
         this.player = player;
         this.onBuyCallback = onBuyCallback;
         this.difficultyManager = difficultyManager;

--- a/core/src/main/java/com/farmgame/ui/InventorySellWindow.java
+++ b/core/src/main/java/com/farmgame/ui/InventorySellWindow.java
@@ -14,8 +14,8 @@ public class InventorySellWindow extends Window {
     private final Player player;
 
     private final Table contentTable;
-    public InventorySellWindow(String tile, Skin skin, Player player, Runnable onSellCallback) {
-        super(tile, skin);
+    public InventorySellWindow(String title, Skin skin, Player player, Runnable onSellCallback) {
+        super(title, skin);
 
         this.player = player;
         this.onSellCallback = onSellCallback;

--- a/core/src/main/java/com/farmgame/ui/PlantSelectionWindow.java
+++ b/core/src/main/java/com/farmgame/ui/PlantSelectionWindow.java
@@ -19,12 +19,12 @@ public class PlantSelectionWindow extends Window {
     private final OnPlantChosenListener chosenListener;
     private final DifficultyManager difficultyManager;
 
-    public PlantSelectionWindow(String tile, Skin skin, OnPlantChosenListener chosenListener, Player player){
-        this(tile, skin, chosenListener, player, new DifficultyManager());
+    public PlantSelectionWindow(String title, Skin skin, OnPlantChosenListener chosenListener, Player player){
+        this(title, skin, chosenListener, player, new DifficultyManager());
     }
 
-    public PlantSelectionWindow(String tile, Skin skin, OnPlantChosenListener chosenListener, Player player, float difficultyMultiplier){
-        this(tile, skin, chosenListener, player, createDifficultyManager(difficultyMultiplier));
+    public PlantSelectionWindow(String title, Skin skin, OnPlantChosenListener chosenListener, Player player, float difficultyMultiplier){
+        this(title, skin, chosenListener, player, createDifficultyManager(difficultyMultiplier));
     }
 
     private static DifficultyManager createDifficultyManager(float multiplier) {
@@ -33,8 +33,8 @@ public class PlantSelectionWindow extends Window {
         return manager;
     }
 
-    public PlantSelectionWindow(String tile, Skin skin, OnPlantChosenListener chosenListener, Player player, DifficultyManager difficultyManager){
-        super(tile, skin);
+    public PlantSelectionWindow(String title, Skin skin, OnPlantChosenListener chosenListener, Player player, DifficultyManager difficultyManager){
+        super(title, skin);
         this.chosenListener = chosenListener;
         this.difficultyManager = difficultyManager;
 


### PR DESCRIPTION
## Summary
- rename `tile` constructor parameters to `title`
- update calls to `super(title, skin)` in all affected classes

## Testing
- `./gradlew core:compileJava`
- `./gradlew test` *(fails: cannot find Java installation)*
- `./gradlew core:test`


------
https://chatgpt.com/codex/tasks/task_e_68518ea99278832e9623b42b86b0a25a